### PR TITLE
Use acm.Certificate instead of deprecated acm.DnsValidatedCertificate…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AWS CDK: Static Website
 
 An AWS CDK Level 3 construct that implements an opinionated static website in AWS using:
+
 - A public readable S3 bucket, that mirrors the contents of local directory of `.html` files and related assets
 - A CloudFront distribution, that caches the S3 delivery and enforces HTTPS
 - Route53 record(s) that route one or multiple public domains to S3
@@ -19,12 +20,13 @@ $ npm install @ukautz/aws-cdk-static-website
 Then in your stack:
 
 ```typescript
-import * as cdk from '@aws-cdk/core';
-import * as route53 from '@aws-cdk/aws-route53';
+import * as cdk from 'aws-cdk-lib';
+import { aws_route53 as route53 } from 'aws-cdk-lib';
 import { StaticWebsite } from '@ukautz/aws-cdk-static-website';
+import { Construct } from 'constructs';
 
 export class YourStack extends cdk.Stack {
-  constructor(scope: cdk.Construct, id: string, props?: cdk.Stack) {
+  constructor(scope: Construct, id: string, props?: cdk.Stack) {
     super(scope, id, props);
 
     // load (or create) a hosted zone, in which the record(s) will be created

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -250,11 +250,10 @@ export class StaticWebsite extends Construct {
     } else if (props.certificate) {
       return props.certificate;
     }
-    return new acm.DnsValidatedCertificate(this, 'Certificate', {
+    return new acm.Certificate(this, 'Certificate', {
       domainName: props.domain,
       subjectAlternativeNames: props.domainAliases,
-      hostedZone: this.hostedZone,
-      region: 'us-east-1',
+      validation: acm.CertificateValidation.fromDns(this.hostedZone),
     });
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/test/__snapshots__/static-website.test.ts.snap
+++ b/test/__snapshots__/static-website.test.ts.snap
@@ -240,143 +240,26 @@ exports[`Stack Website CDN Cache Duration Has consistent snapshot 1`] = `
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "MyTestConstructCertificateCertificateRequestorFunctionBE59448E": {
-      "DependsOn": [
-        "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7",
-        "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "861509f9607aa6bb9fd7034fb10fe6f0c60d91dfd7f010b9ef666869dec9bbd9.zip",
-        },
-        "Handler": "index.certificateRequestHandler",
-        "Role": {
-          "Fn::GetAtt": [
-            "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs14.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "acm:RequestCertificate",
-                "acm:DescribeCertificate",
-                "acm:DeleteCertificate",
-                "acm:AddTagsToCertificate",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "route53:GetChange",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "route53:changeResourceRecordSets",
-              "Condition": {
-                "ForAllValues:StringEquals": {
-                  "route53:ChangeResourceRecordSetsActions": [
-                    "UPSERT",
-                  ],
-                  "route53:ChangeResourceRecordSetsRecordTypes": [
-                    "CNAME",
-                  ],
-                },
-                "ForAllValues:StringLike": {
-                  "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
-                    "*.blog.acme.tld",
-                  ],
-                },
-              },
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":route53:::hostedzone/",
-                    {
-                      "Ref": "HostedZoneDB99F866",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7",
-        "Roles": [
-          {
-            "Ref": "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "MyTestConstructCertificateCertificateRequestorResource5D7905BC": {
-      "DeletionPolicy": "Delete",
+    "MyTestConstructCertificate41948685": {
       "Properties": {
         "DomainName": "blog.acme.tld",
-        "HostedZoneId": {
-          "Ref": "HostedZoneDB99F866",
-        },
-        "Region": "us-east-1",
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "MyTestConstructCertificateCertificateRequestorFunctionBE59448E",
-            "Arn",
-          ],
-        },
+        "DomainValidationOptions": [
+          {
+            "DomainName": "blog.acme.tld",
+            "HostedZoneId": {
+              "Ref": "HostedZoneDB99F866",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "Default/MyTestConstruct/Certificate",
+          },
+        ],
+        "ValidationMethod": "DNS",
       },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
+      "Type": "AWS::CertificateManager::Certificate",
     },
     "MyTestConstructDeploymentAwsCliLayerFFFCF7AD": {
       "Properties": {
@@ -471,10 +354,7 @@ exports[`Stack Website CDN Cache Duration Has consistent snapshot 1`] = `
           ],
           "ViewerCertificate": {
             "AcmCertificateArn": {
-              "Fn::GetAtt": [
-                "MyTestConstructCertificateCertificateRequestorResource5D7905BC",
-                "Arn",
-              ],
+              "Ref": "MyTestConstructCertificate41948685",
             },
             "MinimumProtocolVersion": "TLSv1.2_2021",
             "SslSupportMethod": "sni-only",
@@ -815,143 +695,26 @@ exports[`Stack Website CDN Custom Error Page Has consistent snapshot 1`] = `
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "MyTestConstructCertificateCertificateRequestorFunctionBE59448E": {
-      "DependsOn": [
-        "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7",
-        "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "861509f9607aa6bb9fd7034fb10fe6f0c60d91dfd7f010b9ef666869dec9bbd9.zip",
-        },
-        "Handler": "index.certificateRequestHandler",
-        "Role": {
-          "Fn::GetAtt": [
-            "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs14.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "acm:RequestCertificate",
-                "acm:DescribeCertificate",
-                "acm:DeleteCertificate",
-                "acm:AddTagsToCertificate",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "route53:GetChange",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "route53:changeResourceRecordSets",
-              "Condition": {
-                "ForAllValues:StringEquals": {
-                  "route53:ChangeResourceRecordSetsActions": [
-                    "UPSERT",
-                  ],
-                  "route53:ChangeResourceRecordSetsRecordTypes": [
-                    "CNAME",
-                  ],
-                },
-                "ForAllValues:StringLike": {
-                  "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
-                    "*.blog.acme.tld",
-                  ],
-                },
-              },
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":route53:::hostedzone/",
-                    {
-                      "Ref": "HostedZoneDB99F866",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7",
-        "Roles": [
-          {
-            "Ref": "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "MyTestConstructCertificateCertificateRequestorResource5D7905BC": {
-      "DeletionPolicy": "Delete",
+    "MyTestConstructCertificate41948685": {
       "Properties": {
         "DomainName": "blog.acme.tld",
-        "HostedZoneId": {
-          "Ref": "HostedZoneDB99F866",
-        },
-        "Region": "us-east-1",
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "MyTestConstructCertificateCertificateRequestorFunctionBE59448E",
-            "Arn",
-          ],
-        },
+        "DomainValidationOptions": [
+          {
+            "DomainName": "blog.acme.tld",
+            "HostedZoneId": {
+              "Ref": "HostedZoneDB99F866",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "Default/MyTestConstruct/Certificate",
+          },
+        ],
+        "ValidationMethod": "DNS",
       },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
+      "Type": "AWS::CertificateManager::Certificate",
     },
     "MyTestConstructDeploymentAwsCliLayerFFFCF7AD": {
       "Properties": {
@@ -1054,10 +817,7 @@ exports[`Stack Website CDN Custom Error Page Has consistent snapshot 1`] = `
           ],
           "ViewerCertificate": {
             "AcmCertificateArn": {
-              "Fn::GetAtt": [
-                "MyTestConstructCertificateCertificateRequestorResource5D7905BC",
-                "Arn",
-              ],
+              "Ref": "MyTestConstructCertificate41948685",
             },
             "MinimumProtocolVersion": "TLSv1.2_2021",
             "SslSupportMethod": "sni-only",
@@ -1398,143 +1158,26 @@ exports[`Stack Website Default Has consistent snapshot 1`] = `
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "MyTestConstructCertificateCertificateRequestorFunctionBE59448E": {
-      "DependsOn": [
-        "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7",
-        "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "861509f9607aa6bb9fd7034fb10fe6f0c60d91dfd7f010b9ef666869dec9bbd9.zip",
-        },
-        "Handler": "index.certificateRequestHandler",
-        "Role": {
-          "Fn::GetAtt": [
-            "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs14.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "acm:RequestCertificate",
-                "acm:DescribeCertificate",
-                "acm:DeleteCertificate",
-                "acm:AddTagsToCertificate",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "route53:GetChange",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "route53:changeResourceRecordSets",
-              "Condition": {
-                "ForAllValues:StringEquals": {
-                  "route53:ChangeResourceRecordSetsActions": [
-                    "UPSERT",
-                  ],
-                  "route53:ChangeResourceRecordSetsRecordTypes": [
-                    "CNAME",
-                  ],
-                },
-                "ForAllValues:StringLike": {
-                  "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
-                    "*.blog.acme.tld",
-                  ],
-                },
-              },
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":route53:::hostedzone/",
-                    {
-                      "Ref": "HostedZoneDB99F866",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7",
-        "Roles": [
-          {
-            "Ref": "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "MyTestConstructCertificateCertificateRequestorResource5D7905BC": {
-      "DeletionPolicy": "Delete",
+    "MyTestConstructCertificate41948685": {
       "Properties": {
         "DomainName": "blog.acme.tld",
-        "HostedZoneId": {
-          "Ref": "HostedZoneDB99F866",
-        },
-        "Region": "us-east-1",
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "MyTestConstructCertificateCertificateRequestorFunctionBE59448E",
-            "Arn",
-          ],
-        },
+        "DomainValidationOptions": [
+          {
+            "DomainName": "blog.acme.tld",
+            "HostedZoneId": {
+              "Ref": "HostedZoneDB99F866",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "Default/MyTestConstruct/Certificate",
+          },
+        ],
+        "ValidationMethod": "DNS",
       },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
+      "Type": "AWS::CertificateManager::Certificate",
     },
     "MyTestConstructDeploymentAwsCliLayerFFFCF7AD": {
       "Properties": {
@@ -1629,10 +1272,7 @@ exports[`Stack Website Default Has consistent snapshot 1`] = `
           ],
           "ViewerCertificate": {
             "AcmCertificateArn": {
-              "Fn::GetAtt": [
-                "MyTestConstructCertificateCertificateRequestorResource5D7905BC",
-                "Arn",
-              ],
+              "Ref": "MyTestConstructCertificate41948685",
             },
             "MinimumProtocolVersion": "TLSv1.2_2021",
             "SslSupportMethod": "sni-only",
@@ -1973,147 +1613,35 @@ exports[`Stack Website Domain aliases Has consistent snapshot 1`] = `
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "MyTestConstructCertificateCertificateRequestorFunctionBE59448E": {
-      "DependsOn": [
-        "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7",
-        "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "861509f9607aa6bb9fd7034fb10fe6f0c60d91dfd7f010b9ef666869dec9bbd9.zip",
-        },
-        "Handler": "index.certificateRequestHandler",
-        "Role": {
-          "Fn::GetAtt": [
-            "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs14.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "acm:RequestCertificate",
-                "acm:DescribeCertificate",
-                "acm:DeleteCertificate",
-                "acm:AddTagsToCertificate",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "route53:GetChange",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "route53:changeResourceRecordSets",
-              "Condition": {
-                "ForAllValues:StringEquals": {
-                  "route53:ChangeResourceRecordSetsActions": [
-                    "UPSERT",
-                  ],
-                  "route53:ChangeResourceRecordSetsRecordTypes": [
-                    "CNAME",
-                  ],
-                },
-                "ForAllValues:StringLike": {
-                  "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
-                    "*.blog.acme.tld",
-                    "*.www.blog.acme.tld",
-                  ],
-                },
-              },
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":route53:::hostedzone/",
-                    {
-                      "Ref": "HostedZoneDB99F866",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7",
-        "Roles": [
-          {
-            "Ref": "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "MyTestConstructCertificateCertificateRequestorResource5D7905BC": {
-      "DeletionPolicy": "Delete",
+    "MyTestConstructCertificate41948685": {
       "Properties": {
         "DomainName": "blog.acme.tld",
-        "HostedZoneId": {
-          "Ref": "HostedZoneDB99F866",
-        },
-        "Region": "us-east-1",
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "MyTestConstructCertificateCertificateRequestorFunctionBE59448E",
-            "Arn",
-          ],
-        },
+        "DomainValidationOptions": [
+          {
+            "DomainName": "blog.acme.tld",
+            "HostedZoneId": {
+              "Ref": "HostedZoneDB99F866",
+            },
+          },
+          {
+            "DomainName": "www.blog.acme.tld",
+            "HostedZoneId": {
+              "Ref": "HostedZoneDB99F866",
+            },
+          },
+        ],
         "SubjectAlternativeNames": [
           "www.blog.acme.tld",
         ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "Default/MyTestConstruct/Certificate",
+          },
+        ],
+        "ValidationMethod": "DNS",
       },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
+      "Type": "AWS::CertificateManager::Certificate",
     },
     "MyTestConstructDeploymentAwsCliLayerFFFCF7AD": {
       "Properties": {
@@ -2209,10 +1737,7 @@ exports[`Stack Website Domain aliases Has consistent snapshot 1`] = `
           ],
           "ViewerCertificate": {
             "AcmCertificateArn": {
-              "Fn::GetAtt": [
-                "MyTestConstructCertificateCertificateRequestorResource5D7905BC",
-                "Arn",
-              ],
+              "Ref": "MyTestConstructCertificate41948685",
             },
             "MinimumProtocolVersion": "TLSv1.2_2021",
             "SslSupportMethod": "sni-only",
@@ -2580,143 +2105,26 @@ exports[`Stack Website Storage Bucket Prefix Has consistent snapshot 1`] = `
       },
       "Type": "AWS::S3::BucketPolicy",
     },
-    "MyTestConstructCertificateCertificateRequestorFunctionBE59448E": {
-      "DependsOn": [
-        "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7",
-        "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-      ],
-      "Properties": {
-        "Code": {
-          "S3Bucket": {
-            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
-          },
-          "S3Key": "861509f9607aa6bb9fd7034fb10fe6f0c60d91dfd7f010b9ef666869dec9bbd9.zip",
-        },
-        "Handler": "index.certificateRequestHandler",
-        "Role": {
-          "Fn::GetAtt": [
-            "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs14.x",
-        "Timeout": 900,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "acm:RequestCertificate",
-                "acm:DescribeCertificate",
-                "acm:DeleteCertificate",
-                "acm:AddTagsToCertificate",
-              ],
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "route53:GetChange",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-            {
-              "Action": "route53:changeResourceRecordSets",
-              "Condition": {
-                "ForAllValues:StringEquals": {
-                  "route53:ChangeResourceRecordSetsActions": [
-                    "UPSERT",
-                  ],
-                  "route53:ChangeResourceRecordSetsRecordTypes": [
-                    "CNAME",
-                  ],
-                },
-                "ForAllValues:StringLike": {
-                  "route53:ChangeResourceRecordSetsNormalizedRecordNames": [
-                    "*.blog.acme.tld",
-                  ],
-                },
-              },
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:",
-                    {
-                      "Ref": "AWS::Partition",
-                    },
-                    ":route53:::hostedzone/",
-                    {
-                      "Ref": "HostedZoneDB99F866",
-                    },
-                  ],
-                ],
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleDefaultPolicy36F812A7",
-        "Roles": [
-          {
-            "Ref": "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "MyTestConstructCertificateCertificateRequestorFunctionServiceRoleF0CE0CC7": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "MyTestConstructCertificateCertificateRequestorResource5D7905BC": {
-      "DeletionPolicy": "Delete",
+    "MyTestConstructCertificate41948685": {
       "Properties": {
         "DomainName": "blog.acme.tld",
-        "HostedZoneId": {
-          "Ref": "HostedZoneDB99F866",
-        },
-        "Region": "us-east-1",
-        "ServiceToken": {
-          "Fn::GetAtt": [
-            "MyTestConstructCertificateCertificateRequestorFunctionBE59448E",
-            "Arn",
-          ],
-        },
+        "DomainValidationOptions": [
+          {
+            "DomainName": "blog.acme.tld",
+            "HostedZoneId": {
+              "Ref": "HostedZoneDB99F866",
+            },
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": "Default/MyTestConstruct/Certificate",
+          },
+        ],
+        "ValidationMethod": "DNS",
       },
-      "Type": "AWS::CloudFormation::CustomResource",
-      "UpdateReplacePolicy": "Delete",
+      "Type": "AWS::CertificateManager::Certificate",
     },
     "MyTestConstructDeploymentAwsCliLayerFFFCF7AD": {
       "Properties": {
@@ -2813,10 +2221,7 @@ exports[`Stack Website Storage Bucket Prefix Has consistent snapshot 1`] = `
           ],
           "ViewerCertificate": {
             "AcmCertificateArn": {
-              "Fn::GetAtt": [
-                "MyTestConstructCertificateCertificateRequestorResource5D7905BC",
-                "Arn",
-              ],
+              "Ref": "MyTestConstructCertificate41948685",
             },
             "MinimumProtocolVersion": "TLSv1.2_2021",
             "SslSupportMethod": "sni-only",

--- a/test/static-website.test.ts
+++ b/test/static-website.test.ts
@@ -85,8 +85,8 @@ describe('Stack Website', () => {
 
     // THEN
     assertSnapshot(stack);
-    test('Used in certificate generation', () => {
-      template.hasResourceProperties('AWS::CloudFormation::CustomResource', {
+    test('Used in certificate', () => {
+      template.hasResourceProperties('AWS::CertificateManager::Certificate', {
         DomainName: 'blog.acme.tld',
         SubjectAlternativeNames: ['www.blog.acme.tld'],
       });


### PR DESCRIPTION
… to create certificate which is validated using DNS records in hosted zone